### PR TITLE
Add error callback to asynchronous require

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ If the global variable `require` is set to an object before `require.js` appears
 
 `require.config({ warnings: false });` to disable console warnings.
 
+### error callback
+
+When using the asynchronous form of `require`, you can pass a third argument which will be treated as an error callback. This can be useful when converting an asynchronous require call to a promise:
+
+    return new Promise((resolve, reject) => {
+      require(['moduleName'], resolve, reject);
+    }));
+
+In fact, this is how Typescript and Babel compile asynchronous imports when targeting AMD modules.
+
+When an error handler is present, what would have once been a fatal error while resolving modules will now instead allow module resolution to continue. Your error handler can then throw an exception if the caught error is truly unrecoverable.
+
 ## Author
 
 Raymond Lam (rlam@athenahealth.com)
@@ -83,6 +95,7 @@ Raymond Lam (rlam@athenahealth.com)
 ## Contributors
 
 - Edward Pastuszenski (epastuszenski@athenahealth.com)
+- Andrew Harris (anharris@athenahealth.com)
 
 ## License
 

--- a/require.js
+++ b/require.js
@@ -442,7 +442,7 @@ function _require() {
       // looking for, throw an error.
       else if (_isReady && resolveStatus.moduleNotDefined) {
         if (errorCallback) {
-          errorCallback(_getResolveError(resolveStatus));
+          errorCallback(_getResolveErrorMessage(resolveStatus));
           return true;
         }
         else {
@@ -850,11 +850,11 @@ function _stopTimer () {
 // Throws an error with consistent messaging. Takes as its output the return of
 // _resolveTree
 function _throwResolveError(resolveStatus) {
-  throw new Error(_getResolveError(resolveStatus))
+  throw new Error(_getResolveErrorMessage(resolveStatus))
 }
 
 // Gets the message for a resolve error, but does not throw it.
-function _getResolveError(resolveStatus) {
+function _getResolveErrorMessage(resolveStatus) {
   if (resolveStatus.moduleNotDefined) {
     return (
       'Module '

--- a/test/test.js
+++ b/test/test.js
@@ -1049,6 +1049,42 @@ QUnit.test('delayBetweenRequireCallbacks', function(assert) {
 
 });
 
+
+QUnit.test('asynchronous require with error callback', function(assert) { "use strict";
+  var ready = assert.async();
+
+  require([
+    '13-a'
+  ], function() {
+    assert.ok(0, 'no error was thrown')
+  }, function(error) {
+    assert.strictEqual(
+      error, 
+      'Module 13-a or one of its dependencies is not defined.',
+      'error is passed to the error callback'
+    );
+  });
+
+  // Force resolution of the above require, otherwise the
+  // define below will happen first.
+  require.ready();
+
+  define('13-a', function() {
+    return '13-a';
+  });
+
+  require([
+    '13-a'
+  ], function(dep) {
+    assert.strictEqual(dep, '13-a', 'module can be defined later');
+    ready();
+  }, function() {
+    assert.ok(0, "an error was passed to the error callback");
+    ready();
+  });
+
+});
+
 QUnit.test('onReady', function(assert) { "use strict";
   assert.expect(2);
 
@@ -1076,3 +1112,5 @@ QUnit.test('requirejs', function(assert) { "use strict";
   assert.strictEqual(requirejs, require, 'requirejs is the same as require');
 
 });
+
+


### PR DESCRIPTION
ES6 allows you to use the `import` keyword as a function to do an asynchronous require. The function returns a promise of the module.

```
const myModule = import('myModule');
```

When transpiling this with Babel or Typescript to AMD modules, this becomes:

```
const myModule = new Promise((resolve, reject) => {
  require(['myModule'], resolve, reject);
});
```

This is not compatible with athena-require, which throws an error when more than two arguments are passed to `require`. 

Its easy enough to wrap require calls yourself and catch the error to reject the promise, but this means you can't use native ES6 and rely on the transpiler.

This PR allows a third argument to be passed to require.  It is treated as an error callback, and if present it is called with the error message instead of throwing.